### PR TITLE
Bump jetty-server from 9.2.2.v20140723 to 10.0.10 in /emma-gui

### DIFF
--- a/emma-gui/pom.xml
+++ b/emma-gui/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.2.2.v20140723</version>
+            <version>10.0.10</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
### Description

The changes in this pull request update the version of the Jetty server dependency in the emma-gui project's pom.xml file from 9.2.2.v20140723 to 10.0.10.

- Update Jetty server dependency version from 9.2.2.v20140723 to 10.0.10 in pom.xml.