### PR TITLE
Bump jetty-webapp from 9.2.2.v20140723 to 9.4.34.v20201102 in /emma-gui

### DIFF
--- a/emma-gui/pom.xml
+++ b/emma-gui/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.2.2.v20140723</version>
+            <version>9.4.34.v20201102</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
### Description

Updating the Jetty version in the project's `pom.xml` file from `9.2.2.v20140723` to `9.4.34.v20201102`.

Changes:
- Update Jetty version from `9.2.2.v20140723` to `9.4.34.v20201102` in the `pom.xml` file.